### PR TITLE
Clean up and simplify convention plugins configuration

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -14,8 +14,8 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 compileSdk = libs.versions.compileSdk.get().toInt()
 
                 defaultConfig {
-                    minSdk = libs.versions.minSdk.get().toInt()
                     targetSdk = libs.versions.targetSdk.get().toInt()
+                    minSdk = libs.versions.minSdk.get().toInt()
                 }
                 compileOptions {
                     sourceCompatibility = JavaVersion.VERSION_11

--- a/build-logic/convention/src/main/kotlin/AndroidModuleConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidModuleConventionPlugin.kt
@@ -15,7 +15,6 @@ class AndroidModuleConventionPlugin : Plugin<Project> {
 
                 defaultConfig {
                     minSdk = libs.versions.minSdk.get().toInt()
-                    targetSdk = libs.versions.targetSdk.get().toInt()
                 }
                 compileOptions {
                     sourceCompatibility = JavaVersion.VERSION_11

--- a/build-logic/convention/src/main/kotlin/ComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ComposeConventionPlugin.kt
@@ -1,5 +1,4 @@
-import com.android.build.api.dsl.ApplicationExtension
-import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
@@ -9,8 +8,7 @@ class ComposeConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.alias(libs.plugins.kotlin.compose)
 
-            extensions.findByType(ApplicationExtension::class.java)?.let(::configureCompose)
-            extensions.findByType(LibraryExtension::class.java)?.let(::configureCompose)
+            extensions.findByType(CommonExtension::class.java)?.let(::configureCompose)
 
             dependencies {
                 implementation(platform(libs.androidx.compose.bom))

--- a/build-logic/convention/src/main/kotlin/RoomConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/RoomConventionPlugin.kt
@@ -1,5 +1,4 @@
 import androidx.room.gradle.RoomExtension
-import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -10,10 +9,6 @@ class RoomConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.alias(libs.plugins.room)
             pluginManager.alias(libs.plugins.ksp)
-
-            extensions.configure<KspExtension> {
-                arg("room.generateKotlin", "true")
-            }
 
             extensions.configure<RoomExtension> {
                 schemaDirectory("$projectDir/schemas")


### PR DESCRIPTION
### **Auto-created Ticket**

Closes #19 

### **PR Type**
Enhancement


___

### **Description**
- Remove unused `targetSdk` from `AndroidModuleConventionPlugin` library configuration

- Reorder `defaultConfig` properties in `AndroidApplicationConventionPlugin` for consistency

- Replace specific extensions with `CommonExtension` in `ComposeConventionPlugin`

- Eliminate unnecessary KSP argument configuration in `RoomConventionPlugin`


___



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AndroidApplicationConventionPlugin.kt</strong><dd><code>Reorder defaultConfig properties for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt

<ul><li>Reordered <code>defaultConfig</code> properties: moved <code>targetSdk</code> after <code>minSdk</code> for <br>better readability<br> <li> No functional changes, purely organizational improvement</ul>


</details>


  </td>
  <td><a href="https://github.com/amineharbaoui/lazy-pizza/pull/18/files#diff-6f219b940c62174bcc616df1cf6d1e1342046ae168ca268f5d858920d87465ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AndroidModuleConventionPlugin.kt</strong><dd><code>Remove unused targetSdk from library configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/src/main/kotlin/AndroidModuleConventionPlugin.kt

<ul><li>Removed unused <code>targetSdk</code> configuration from <code>LibraryExtension</code> <br>defaultConfig<br> <li> Library modules do not require explicit targetSdk setting</ul>


</details>


  </td>
  <td><a href="https://github.com/amineharbaoui/lazy-pizza/pull/18/files#diff-d1a14b9fc3d650cad77a1c0d253d8931aa5ad9d15333294ce9f979debc7867eb">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ComposeConventionPlugin.kt</strong><dd><code>Consolidate extension types to CommonExtension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/src/main/kotlin/ComposeConventionPlugin.kt

<ul><li>Replaced specific <code>ApplicationExtension</code> and <code>LibraryExtension</code> imports <br>with unified <code>CommonExtension</code><br> <li> Consolidated two separate extension type checks into single <br><code>CommonExtension</code> check<br> <li> Commented out old extension-specific code for reference</ul>


</details>


  </td>
  <td><a href="https://github.com/amineharbaoui/lazy-pizza/pull/18/files#diff-6e7cf759478b9940bc0c230088428d83ea1a48920237633d1c6b62cf4b862c34">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RoomConventionPlugin.kt</strong><dd><code>Remove unnecessary KSP argument configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/src/main/kotlin/RoomConventionPlugin.kt

<ul><li>Removed unused <code>KspExtension</code> import<br> <li> Eliminated unnecessary KSP argument configuration block <br>(<code>room.generateKotlin</code> setting)<br> <li> Kept <code>RoomExtension</code> configuration for schema directory</ul>


</details>


  </td>
  <td><a href="https://github.com/amineharbaoui/lazy-pizza/pull/18/files#diff-8cf77185db822576f1568bd2fe6c77b51e4451ae91179bf06295fd32e39ef167">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

