### PR TITLE
Add GitHub Actions workflow for automated APK releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release APK
+
+on:
+    push:
+        tags:
+            - "v*.*.*"
+
+permissions:
+    contents: write
+
+jobs:
+    release-apk:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@v5
+              with:
+                  distribution: temurin
+                  java-version: 17
+
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v5
+
+            - name: Decode release keystore
+              run: |
+                  echo "${{ secrets.LAZYPIZZA_KEYSTORE_BASE64 }}" | base64 --decode > "${{ github.workspace }}/release.keystore"
+
+            - name: Assemble Release APK
+              env:
+                  LAZYPIZZA_STORE_FILE: ${{ github.workspace }}/release.keystore
+                  LAZYPIZZA_STORE_PASSWORD: ${{ secrets.LAZYPIZZA_STORE_PASSWORD }}
+                  LAZYPIZZA_KEY_ALIAS: ${{ secrets.LAZYPIZZA_KEY_ALIAS }}
+                  LAZYPIZZA_KEY_PASSWORD: ${{ secrets.LAZYPIZZA_KEY_PASSWORD }}
+              run: ./gradlew --no-daemon :app:assembleRelease
+
+            - name: Rename APK with version
+              run: |
+                  VERSION="${GITHUB_REF_NAME}"
+                  mv app/build/outputs/apk/release/app-release.apk "app/build/outputs/apk/release/lazy-pizza-${VERSION}.apk"
+
+            - name: Publish GitHub Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  files: app/build/outputs/apk/release/lazy-pizza-${{ github.ref_name }}.apk
+                  generate_release_notes: true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,11 +20,16 @@ android {
     }
 
     signingConfigs {
-        register("release") {
-            storeFile = providers.gradleProperty("LAZYPIZZA_STORE_FILE").orNull?.let(::file)
-            storePassword = providers.gradleProperty("LAZYPIZZA_STORE_PASSWORD").orNull
-            keyAlias = providers.gradleProperty("LAZYPIZZA_KEY_ALIAS").orNull
-            keyPassword = providers.gradleProperty("LAZYPIZZA_KEY_PASSWORD").orNull
+        create("release") {
+            val isReleaseBuild = gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }
+            if (!isReleaseBuild) return@create
+            fun propOrEnv(name: String): String = providers.gradleProperty(name).orNull
+                ?: System.getenv(name)
+
+            storeFile = file(propOrEnv("LAZYPIZZA_STORE_FILE"))
+            storePassword = propOrEnv("LAZYPIZZA_STORE_PASSWORD")
+            keyAlias = propOrEnv("LAZYPIZZA_KEY_ALIAS")
+            keyPassword = propOrEnv("LAZYPIZZA_KEY_PASSWORD")
         }
     }
 


### PR DESCRIPTION
### **Auto-created Ticket**

- Closes #53

### **PR Type**
Enhancement


___

### **Description**
- Automates APK assembly and release publishing via GitHub Actions

- Triggers on semantic version tags (v*.*.*)

- Decodes keystore and signs APK with release credentials

- Publishes signed APK as GitHub Release asset


___



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>GitHub Actions workflow for APK release automation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>New workflow triggered on version tags (v*.*.*)<br> <li> Sets up JDK 17 and Gradle build environment<br> <li> Decodes base64-encoded keystore from secrets<br> <li> Assembles signed release APK with credentials<br> <li> Publishes APK to GitHub Releases with auto-generated notes</ul>


</details>


  </td>
  <td><a href="https://github.com/amineharbaoui/lazy-pizza/pull/52/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

