### PR TITLE
refactor(auth): replace `isSignedIn` logic with `userIdFlow` for better state management

### DIFF
--- a/features/auth/data/src/main/java/com/example/auth/data/datasource/PhoneAuthDataSource.kt
+++ b/features/auth/data/src/main/java/com/example/auth/data/datasource/PhoneAuthDataSource.kt
@@ -12,27 +12,16 @@ import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-
 class PhoneAuthDataSource @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
 ) {
 
-    // TODO Unify userIdFlow and isSignedIn
     val userIdFlow: Flow<String?> = callbackFlow {
         val listener = FirebaseAuth.AuthStateListener { auth ->
             trySend(auth.currentUser?.uid)
         }
         firebaseAuth.addAuthStateListener(listener)
         trySend(firebaseAuth.currentUser?.uid)
-        awaitClose { firebaseAuth.removeAuthStateListener(listener) }
-    }
-
-    val isSignedIn: Flow<Boolean> = callbackFlow {
-        val listener = FirebaseAuth.AuthStateListener { auth ->
-            trySend(auth.currentUser != null)
-        }
-        firebaseAuth.addAuthStateListener(listener)
-        trySend(firebaseAuth.currentUser != null)
         awaitClose { firebaseAuth.removeAuthStateListener(listener) }
     }
 

--- a/features/auth/data/src/main/java/com/example/auth/data/repository/SessionRepositoryImpl.kt
+++ b/features/auth/data/src/main/java/com/example/auth/data/repository/SessionRepositoryImpl.kt
@@ -12,8 +12,5 @@ class SessionRepositoryImpl @Inject constructor(
     override val userIdFlow: Flow<String?>
         get() = phoneAuthDataSource.userIdFlow
 
-    override val isSignedIn: Flow<Boolean>
-        get() = phoneAuthDataSource.isSignedIn
-
     override suspend fun currentUserUid(): String? = phoneAuthDataSource.getCurrentUser()?.uid
 }

--- a/features/auth/data/src/test/java/com/example/auth/data/datasource/PhoneAuthDataSourceTest.kt
+++ b/features/auth/data/src/test/java/com/example/auth/data/datasource/PhoneAuthDataSourceTest.kt
@@ -16,14 +16,12 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MockKExtension::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class PhoneAuthDataSourceTest {
 
     @MockK(relaxed = true)
@@ -71,30 +69,6 @@ class PhoneAuthDataSourceTest {
 
         // Then
         assertThat(emittedUserId).isNull()
-    }
-
-    @Test
-    suspend fun `isSignedIn when user is logged in then emits true`() {
-        // Given
-        given { firebaseAuth.currentUser } returns firebaseUser
-
-        // When
-        val isSignedIn = phoneAuthDataSource.isSignedIn.first()
-
-        // Then
-        assertThat(isSignedIn).isTrue
-    }
-
-    @Test
-    suspend fun `isSignedIn when no user logged in then emits false`() {
-        // Given
-        given { firebaseAuth.currentUser } returns null
-
-        // When
-        val isSignedIn = phoneAuthDataSource.isSignedIn.first()
-
-        // Then
-        assertThat(isSignedIn).isFalse
     }
 
     @Test

--- a/features/auth/data/src/test/java/com/example/auth/data/repository/PhoneAuthRepositoryImplTest.kt
+++ b/features/auth/data/src/test/java/com/example/auth/data/repository/PhoneAuthRepositoryImplTest.kt
@@ -10,13 +10,11 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.just
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MockKExtension::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class PhoneAuthRepositoryImplTest {
 
     @MockK

--- a/features/auth/data/src/test/java/com/example/auth/data/repository/SessionRepositoryImplTest.kt
+++ b/features/auth/data/src/test/java/com/example/auth/data/repository/SessionRepositoryImplTest.kt
@@ -39,23 +39,6 @@ class SessionRepositoryImplTest {
     }
 
     @Test
-    suspend fun `isSignedIn when subscribed then forwards data from phone auth data source`() {
-        // Given
-        val isSignedInFlow = MutableStateFlow(false)
-        given { phoneAuthDataSource.isSignedIn } returns isSignedInFlow
-
-        // When
-        sessionRepositoryImpl.isSignedIn.test {
-            // Then
-            assertThat(awaitItem()).isFalse()
-
-            isSignedInFlow.tryEmit(true)
-            assertThat(awaitItem()).isTrue()
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     suspend fun `currentUserUid when called then returns current user uid from phone auth data source`() {
         // Given
         val mockUid = "user-id-123"

--- a/features/auth/domain/src/main/java/com/example/auth/domain/repository/SessionRepository.kt
+++ b/features/auth/domain/src/main/java/com/example/auth/domain/repository/SessionRepository.kt
@@ -4,6 +4,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface SessionRepository {
     val userIdFlow: Flow<String?>
-    val isSignedIn: Flow<Boolean>
     suspend fun currentUserUid(): String?
 }

--- a/features/auth/domain/src/main/java/com/example/auth/domain/usecase/ObserveUserIdFlowUseCase.kt
+++ b/features/auth/domain/src/main/java/com/example/auth/domain/usecase/ObserveUserIdFlowUseCase.kt
@@ -4,8 +4,8 @@ import com.example.auth.domain.repository.SessionRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class ObserveIsSignedInUseCase @Inject constructor(
+class ObserveUserIdFlowUseCase @Inject constructor(
     private val sessionRepository: SessionRepository,
 ) {
-    operator fun invoke(): Flow<Boolean> = sessionRepository.isSignedIn
+    operator fun invoke(): Flow<String?> = sessionRepository.userIdFlow
 }

--- a/features/auth/domain/src/test/java/com/example/auth/domain/usecase/ObserveUserIdFlowUseCaseTest.kt
+++ b/features/auth/domain/src/test/java/com/example/auth/domain/usecase/ObserveUserIdFlowUseCaseTest.kt
@@ -12,28 +12,28 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MockKExtension::class)
-class ObserveIsSignedInUseCaseTest {
+class ObserveUserIdFlowUseCaseTest {
 
     @MockK
     private lateinit var sessionRepository: SessionRepository
 
     @InjectMockKs
-    private lateinit var useCase: ObserveIsSignedInUseCase
+    private lateinit var useCase: ObserveUserIdFlowUseCase
 
     @Test
     suspend fun `invoke when is signed in emits values then emits same values`() {
         // Given
-        val isSignedInFlow = MutableStateFlow(false)
-        given { sessionRepository.isSignedIn } returns isSignedInFlow
+        val userId: MutableStateFlow<String?> = MutableStateFlow(null)
+        given { sessionRepository.userIdFlow } returns userId
 
         // When
         useCase().test {
             // Then
-            isSignedInFlow.tryEmit(false)
-            assertThat(awaitItem()).isFalse()
+            userId.tryEmit(null)
+            assertThat(awaitItem()).isNull()
 
-            isSignedInFlow.tryEmit(true)
-            assertThat(awaitItem()).isTrue()
+            userId.tryEmit("user-id-123")
+            assertThat(awaitItem()).isEqualTo("user-id-123")
 
             cancelAndIgnoreRemainingEvents()
         }

--- a/features/auth/ui-login/src/test/java/com/example/auth/ui/login/PhoneAuthViewModelTest.kt
+++ b/features/auth/ui-login/src/test/java/com/example/auth/ui/login/PhoneAuthViewModelTest.kt
@@ -12,7 +12,6 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.just
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 
 @ExtendWith(MockKExtension::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class PhoneAuthViewModelTest {
 
     @JvmField

--- a/features/menu/ui-home/src/main/java/com/example/menu/ui/home/MenuViewModel.kt
+++ b/features/menu/ui-home/src/main/java/com/example/menu/ui/home/MenuViewModel.kt
@@ -2,7 +2,7 @@ package com.example.menu.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.auth.domain.usecase.ObserveIsSignedInUseCase
+import com.example.auth.domain.usecase.ObserveUserIdFlowUseCase
 import com.example.auth.domain.usecase.SignOutUseCase
 import com.example.cart.domain.usecase.AddCartItemUseCase
 import com.example.cart.domain.usecase.ClearCartUseCase
@@ -32,7 +32,7 @@ class MenuViewModel @Inject constructor(
     private val removeCartItemUseCase: RemoveCartItemUseCase,
     private val clearCartUseCase: ClearCartUseCase,
     private val signOutUseCase: SignOutUseCase,
-    private val observeIsSignedInUseCase: ObserveIsSignedInUseCase,
+    private val observeUserIdFlowUseCase: ObserveUserIdFlowUseCase,
     private val menuMapper: MenuDomainToUiMapper,
 ) : ViewModel() {
 
@@ -52,10 +52,11 @@ class MenuViewModel @Inject constructor(
             combine(
                 observeMenuUseCase(),
                 observeCartUseCase(),
-                observeIsSignedInUseCase(),
-            ) { menuSections, cart, isSignedIn ->
+                observeUserIdFlowUseCase(),
+            ) { menuSections, cart, userId ->
                 val current = _uiState.value.content
                 val searchQuery = if (current is MenuContentUiState.Ready) current.searchQuery else ""
+                val isSignedIn = userId != null
 
                 val nextContent = menuMapper.mapToMenuContentUiState(menuSections, cart, searchQuery)
                 allSections = (nextContent as? MenuContentUiState.Ready)?.originalMenu ?: emptyList()


### PR DESCRIPTION
- Removed `isSignedIn` from `SessionRepository` and related tests.
- Updated `ObserveIsSignedInUseCase` to `ObserveUserIdFlowUseCase`.
- Replaced downstream usages of `isSignedIn` with `userIdFlow`.
- Simplified tests and ViewModel logic to align with the new flow.